### PR TITLE
Publishing sassdoc docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 *.sublime*
 *.gem
+.pages
+.sassdoc

--- a/.sassdocrc
+++ b/.sassdocrc
@@ -1,0 +1,12 @@
+basePath: "https://github.com/lunelson/sass-maps-plus/blob/master"
+display:
+    access: ["public", "private"]
+    alias: false
+    watermark: true
+
+package: "./package.json"
+theme: "default"
+groups:
+    helpers: "Helpers"
+    api: "API"
+    list-map: "Old List-Maps API"

--- a/_sass-maps-plus.scss
+++ b/_sass-maps-plus.scss
@@ -1,8 +1,8 @@
 ////
 ///  Sass Maps Plus 0.9.0
 ///  Advanced map and list-map manipulation for all versions of Sass
-///  @author @lunelson
 ///  MIT License
+///  @author Lu Nelson
 ////
 
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "title": "Sass Maps Plus",
   "name": "sass-maps-plus",
   "version": "0.9.5",
   "description": "Advanced map and list-map manipulation for all versions of Sass",


### PR DESCRIPTION
I have done some tiny changes for the upcoming SassDoc docs.

To finalize the whole thing, you need to:
1. Merge this PR.
2. Install SassDoc on your machine: `npm install -g sassdoc@2.0.0-rc.16`.
3. Install sassdocify on your machine: `npm install -g sassdocify`.
4. Make sure it is in your path: `export PATH="$PWD/bin:$PATH"`.
5. Run sassdocify: `sassdocify`.
6. Publish on GHPages: `cd .pages && git push -u origin gh-pages`.

Then, every time you want to refresh the docs, you only have to repeat steps 5 and 6, or in a single command: `sassdocify && cd .pages && git push -u origin gh-pages`.

Everything else is automated. :)
